### PR TITLE
Replace gulp-cssnano

### DIFF
--- a/modules/gulp-build/README.md
+++ b/modules/gulp-build/README.md
@@ -14,11 +14,12 @@ npm install @modularbp/gulp-build --save-dev
 | Module | Description |
 | ------ | ----------- |
 | [gulp] | The build system |
-| [gulp-cssnano] | Minify CSS |
+| [cssnano] | Minify CSS |
 | [gulp-htmlmin] | Minify HTML |
+| [gulp-postcss] | Transform CSS |
 | [gulp-uglify] | Minify JS |
 
 [gulp]: https://github.com/gulpjs/gulp
-[gulp-cssnano]: https://github.com/ben-eb/gulp-cssnano
 [gulp-htmlmin]: https://github.com/jonschlinkert/gulp-htmlmin
+[gulp-postcss]: https://github.com/postcss/gulp-postcss
 [gulp-uglify]: https://github.com/terinjokes/gulp-uglify

--- a/modules/gulp-build/package.json
+++ b/modules/gulp-build/package.json
@@ -10,9 +10,10 @@
   },
   "homepage": "https://github.com/modularbp/modular-gulp/tree/master/modules/gulp-build#readme",
   "dependencies": {
+    "cssnano": "*",
     "gulp": "*",
-    "gulp-cssnano": "*",
     "gulp-htmlmin": "*",
+    "gulp-postcss": "*",
     "gulp-uglify": "*"
   }
 }

--- a/modules/gulp-build/src/build.js
+++ b/modules/gulp-build/src/build.js
@@ -1,13 +1,18 @@
 import gulp from 'gulp';
-import cssnano from 'gulp-cssnano';
+import postcss from 'gulp-postcss';
+import cssnano from 'cssnano';
 import uglify from 'gulp-uglify';
 import htmlmin from 'gulp-htmlmin';
 import paths from '../mconfig.json';
 
 function buildStyles() {
+    const plugins = [
+        cssnano()
+    ];
+
     return gulp
         .src(paths.styles.dest + '*.css')
-        .pipe(cssnano())
+        .pipe(postcss(plugins))
         .pipe(gulp.dest(paths.styles.dest));
 }
 


### PR DESCRIPTION
Deprecated (on GitHub) in favor of gulp-postcss + cssnano.

See: https://github.com/ben-eb/gulp-cssnano

---

Resolves vulnerability in js-yaml <3.13.0 reported by NPM audit:

```
 @modularbp/gulp-build > gulp-cssnano > cssnano > postcss-svgo > svgo > js-yaml
```